### PR TITLE
remove name and type from creators template file

### DIFF
--- a/inst/templates/creators.csv
+++ b/inst/templates/creators.csv
@@ -1,1 +1,1 @@
-﻿name,type,id,givenName,familyName,affilitation,email
+id,givenName,familyName,affilitation,email


### PR DESCRIPTION
seems like we dropped these columns for write_spice() but they didn't get taken out of the template csv in `inst`