### PR TITLE
add remote EML dependency. Temporary fix for missing eml2 dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     tidyr,
     ggplot2,
     magrittr,
-    EML
+    EML (>= 1.99.0)
 Suggests: 
     testthat,
     knitr,
@@ -36,3 +36,5 @@ Suggests:
     listviewer
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
+Remotes:  
+    ropensci/EML


### PR DESCRIPTION
Hi Nick,

I'm just adding the remote dependency for now as I'm not sure when EML will be on CRAN. I didn't realise `dataspice` was non-functional at the moment! 🤦‍♀️

I'm going to be teaching on weds using `dataspice` so would be great to get this merged in asap.

Cheers for making the PR by the way!