### PR TITLE
Fix bug where Shiny apps were using checkboxes instead of text

### DIFF
--- a/R/edit_file.R
+++ b/R/edit_file.R
@@ -155,7 +155,9 @@ edit_file <- function(metadata_dir = here::here("data", "metadata"),
     values <- reactiveValues()
 
     dat <- readr::read_csv(file = filepath,
-                           col_types = readr::cols())
+                           col_types = readr::cols(
+                             .default = readr::col_character()
+                           ))
     # pad if no data
     if(nrow(dat) == 0){
       dat <- dplyr::add_row(dat)


### PR DESCRIPTION
When `readr::read_csv` reads a file an empty `readr::cols` `col_types` def, columns with no data get guessed as logical. We change the default here so `readr` never guesses logical.

Closes #81