### PR TITLE
Ak maps gp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     knitr,
     rmarkdown,
     servr,
-    listviewer
+    listviewer,
+    maps
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     jsonlite,
     whisker,
     readr,
-    here,
     stringr,
     tools,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: The goal of dataspice is to make it easier for researchers to creat
 Authors@R: person("First", "Last", email = "first.last@example.com", role = c("aut", "cre"))
 License: MIT + file LICENSE
 URL: https://github.com/ropenscilabs/dataspice
-BugReports: https://github.com/ropenscilabs/datspice/issues
+BugReports: https://github.com/ropenscilabs/dataspice/issues
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,8 @@ Description: The goal of dataspice is to make it easier for researchers to creat
    dataset README webpage and produce more complex metadata formats to aid dataset discovery. Metadata fields are based on schema.org and other metadata standards..
 Authors@R: person("First", "Last", email = "first.last@example.com", role = c("aut", "cre"))
 License: MIT + file LICENSE
+URL: https://github.com/ropenscilabs/dataspice
+BugReports: https://github.com/ropenscilabs/datspice/issues
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dataspice
-Version: 0.0.0.9000
+Version: 0.0.0.901
 Title: Create lightweight schema.org descriptions of dataset
 Description: The goal of dataspice is to make it easier for researchers to create basic, 
    lightweight and concise metadata files for their datasets. These basic files can 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Imports: 
     purrr,
     fs,

--- a/R/edit_file.R
+++ b/R/edit_file.R
@@ -15,7 +15,7 @@
 #' # Specifying a different dataspice metadata directory
 #' edit_attributes(metadata_dir = "analysis/data/metadata/"))
 #'}
-edit_attributes <- function(metadata_dir = here::here("data", "metadata")) {
+edit_attributes <- function(metadata_dir = "data/metadata") {
   edit_file(metadata_dir, "attributes.csv")
 }
 
@@ -43,7 +43,7 @@ edit_creators <- function(metadata_dir = here::here("data", "metadata")) {
 #' @import rhandsontable
 #' @import ggplot2
 #' @importFrom dplyr "%>%"
-edit_file <- function(metadata_dir = here::here("data", "metadata"),
+edit_file <- function(metadata_dir = "data/metadata",
                       file = c("attributes.csv", "biblio.csv", "access.csv", "creators.csv")){
 
   file <- match.arg(file)

--- a/R/edit_file.R
+++ b/R/edit_file.R
@@ -142,7 +142,7 @@ edit_file <- function(metadata_dir = here::here("data", "metadata"),
 
 
     ## bounding box map
-    if (file == "biblio.csv"){
+    if (file == "biblio.csv" & requireNamespace("maps", quietly = TRUE)){
       output$bbmap <- renderPlot({
         world <- ggplot2::map_data("world")
         ggplot2::ggplot() +

--- a/R/edit_file.R
+++ b/R/edit_file.R
@@ -142,7 +142,7 @@ edit_file <- function(metadata_dir = "data/metadata",
 
 
     ## bounding box map
-    if (file == "biblio.csv" & requireNamespace("maps", quietly = TRUE)){
+    if (file == "biblio.csv" && requireNamespace("maps", quietly = TRUE)){
       output$bbmap <- renderPlot({
         world <- ggplot2::map_data("world")
         ggplot2::ggplot() +

--- a/R/prep.R
+++ b/R/prep.R
@@ -34,9 +34,8 @@
 #' # get vector of valid (existing) file paths
 #' validate_file_paths(data_path)
 #' }
-prep_attributes <- function(data_path = here::here("data"),
-                            attributes_path = here::here("data", "metadata",
-                                                         "attributes.csv"),
+prep_attributes <- function(data_path = "data",
+                            attributes_path = "data/metadata/attributes.csv",
                             ...){
   # list and validate file paths
   file_paths <- validate_file_paths(data_path, ...)
@@ -54,7 +53,7 @@ prep_attributes <- function(data_path = here::here("data"),
 
 #' @inherit prep_attributes
 #' @export
-validate_file_paths <- function(data_path = here::here("data"), ...){
+validate_file_paths <- function(data_path = "data", ...){
   if(length(data_path) == 1){
     if(is_dir(data_path)){
       file_paths <- list.files(data_path,

--- a/R/prep.R
+++ b/R/prep.R
@@ -59,13 +59,13 @@ validate_file_paths <- function(data_path = here::here("data"), ...){
     if(is_dir(data_path)){
       file_paths <- list.files(data_path,
                                include.dirs = FALSE,
-                               full.names = T,
+                               full.names = TRUE,
                                ...)
     }else{
       file_paths <- data_path
     }}
     # remove any metadata folder files
-    file_paths <- grep("*metadata/*", file_paths, invert = T, value = T)
+    file_paths <- grep("*metadata/*", file_paths, invert = TRUE, value = TRUE)
     file_paths <- file_paths[!is_dir(file_paths)] %>%
       check_files_exist() %>%
       check_extensions()

--- a/R/prep_access.R
+++ b/R/prep_access.R
@@ -13,9 +13,8 @@
 #' to list files in a folder recursively or use `pattern` to filter files for patterns.
 #' @return Updates `access.csv` and writes to `access_path`.
 #' @export
-prep_access <- function(data_path = here::here("data"),
-                        access_path = here::here("data", "metadata",
-                                                 "access.csv"),
+prep_access <- function(data_path = "data",
+                        access_path = "data/metadata/access.csv",
                                                  ...){
   # check and load attributes
   if(!file.exists(access_path)){

--- a/man/edit_attributes.Rd
+++ b/man/edit_attributes.Rd
@@ -4,7 +4,7 @@
 \alias{edit_attributes}
 \title{Shinyapps for editing dataspice metadata tables}
 \usage{
-edit_attributes(metadata_dir = here::here("data", "metadata"))
+edit_attributes(metadata_dir = "data/metadata")
 }
 \arguments{
 \item{metadata_dir}{the directory containing the \code{dataspice} metadata \code{.csv} files. Defaults to

--- a/man/prep_access.Rd
+++ b/man/prep_access.Rd
@@ -4,11 +4,7 @@
 \alias{prep_access}
 \title{Prepare access}
 \usage{
-prep_access(
-  data_path = here::here("data"),
-  access_path = here::here("data", "metadata", "access.csv"),
-  ...
-)
+prep_access(data_path = "data", access_path = "data/metadata/access.csv", ...)
 }
 \arguments{
 \item{data_path}{character vector of either:

--- a/man/prep_attributes.Rd
+++ b/man/prep_attributes.Rd
@@ -5,8 +5,8 @@
 \title{Prepare attributes}
 \usage{
 prep_attributes(
-  data_path = here::here("data"),
-  attributes_path = here::here("data", "metadata", "attributes.csv"),
+  data_path = "data",
+  attributes_path = "data/metadata/attributes.csv",
   ...
 )
 }

--- a/man/validate_file_paths.Rd
+++ b/man/validate_file_paths.Rd
@@ -4,7 +4,7 @@
 \alias{validate_file_paths}
 \title{Prepare attributes}
 \usage{
-validate_file_paths(data_path = here::here("data"), ...)
+validate_file_paths(data_path = "data", ...)
 }
 \arguments{
 \item{data_path}{character vector of either:


### PR DESCRIPTION
## Add missing `maps` dependecy` for plotting a map in `edit_biblio()`

Quick PR to correct for missing dependency `maps`. This is required for `ggplot2::map_data` but is only a `Suggests` dependency of `ggplot2` so is not installed during `dataspice` installation.

Adding maps to `Imports` means `R CMD CHECK`complains:
```
'loadNamespace' or 'requireNamespace' call not declared from: ‘maps’
```
That's  because `maps::map()` is not called directly in `edit_file()` (rather `ggplot2::map_data()` calls it).

So, I've added `maps` to `Suggest` and added a check for whether it's installed before attempting to plot the map in `edit_file()`. 

## Removing dependence on `here::here()` 

Although seemed a good idea initially, the truth is that `here` is not recommended for use in software as it can have unpredictable behaviour if not working in repo / project / package. I've converted any paths to relative & canonical.


## Minor tweaks in response to `goodpractice::gp()`

- Converted any `T` to `TRUE`
- Added `BugReport` and `URL` fields to `DESCRIPTION`

