### PR TITLE
readr::write_csv now uses `file` rather than `path` argument

### DIFF
--- a/R/prep.R
+++ b/R/prep.R
@@ -45,7 +45,7 @@ prep_attributes <- function(data_path = "data",
                                  purrr::map_df(file_paths,
                                                ~extract_attributes(.x, attributes)))
 
-  readr::write_csv(attributes, path = attributes_path)
+  readr::write_csv(attributes, file = attributes_path)
 }
 
 #' @inherit prep_attributes


### PR DESCRIPTION
`path` argument is now deprecated, generating a warning when running `prep_attributes`. See https://github.com/tidyverse/readr/commit/108fc027592ff77fd5386bf300a76957b065208e#diff-60a8614ff3d671c89ed1096cc7c1ab50c7ea03680e815fcfdef5d71477aee660