### PR TITLE
Fix missing citation

### DIFF
--- a/R/edit_file.R
+++ b/R/edit_file.R
@@ -245,7 +245,8 @@ edit_file <- function(metadata_dir = file.path("data", "metadata"), file) {
     output$hot <- rhandsontable::renderRHandsontable({
       rhandsontable::rhandsontable(dat,
                     useTypes = TRUE,
-                    stretchH = "all") %>%
+                    stretch = 'all',
+                    colWidths = '250px') %>%
         rhandsontable::hot_context_menu(allowColEdit = FALSE)
     })
 

--- a/R/write_spice.R
+++ b/R/write_spice.R
@@ -76,6 +76,7 @@ write_spice <- function(path = file.path("data", "metadata"), ...) {
     creator = authors,
     description = biblio$description,
     datePublished = biblio$datePublished,
+    citation = biblio$citation,
     keywords = biblio_keywords,
     funder = biblio$funder,
     temporalCoverage = paste(biblio$startDate, biblio$endDate, sep="/"),

--- a/inst/template.html5
+++ b/inst/template.html5
@@ -62,6 +62,10 @@
         <td>{{datePublished}}</td>
       </tr>
       <tr>
+        <td>Citation</td>
+        <td>{{citation}}</td>
+      </tr>
+      <tr>
         <td>Keywords</td>
         <td>
           <ul>


### PR DESCRIPTION
The citation field was missing from the output dataspice.json and HTML files. 

I added it back in `write_spice()` and updated the HTML template to drop it into the Bibliographic table. 

(Apologies, the colWidths commit is on this as well, forgot to go back to the main ropensci branch..)