### PR TITLE
Add dataType field to PropertyValue

### DIFF
--- a/R/PropertyValue.R
+++ b/R/PropertyValue.R
@@ -17,6 +17,7 @@ valueReference = NULL,
  disambiguatingDescription = NULL,
  description = NULL,
  alternateName = NULL,
+ dataType = NULL,                        
  additionalType = NULL) {
 Filter(Negate(is.null),
  list(
@@ -39,4 +40,5 @@ identifier = identifier,
 disambiguatingDescription = disambiguatingDescription,
 description = description,
 alternateName = alternateName,
+dataType = dataType,
 additionalType = additionalType))}


### PR DESCRIPTION
I have added a dataType field (https://schema.org/DataType#subtypes) to PropertyValue so that this can be included manually as an extra field in attributes.csv and then get included in the json-ld metadata file when write_spice() is called. (This is based on my need for this field in the json-ld metadata I am trying to generate for a project.)